### PR TITLE
Ported versioninfo to Python3

### DIFF
--- a/PyInstaller/utils/win32/versioninfo.py
+++ b/PyInstaller/utils/win32/versioninfo.py
@@ -12,7 +12,6 @@
 import codecs
 import struct
 
-import pywintypes
 import win32api
 # ::TODO:: #1920 revert to using pypi version
 from ...lib import pefile
@@ -27,25 +26,25 @@ def pefile_read_version(filename):
     {
         # Translation independent information.
         # VS_FIXEDFILEINFO - Contains version information about a file. This information is language and code page independent.
-        u'FileVersion':      (1, 2, 3, 4),
-        u'ProductVersion':   (9, 10, 11, 12),
+        'FileVersion':      (1, 2, 3, 4),
+        'ProductVersion':   (9, 10, 11, 12),
 
         # PE files might contain several translations of version information.
         # VS_VERSIONINFO - Depicts the organization of data in a file-version resource. It is the root structure that contains all other file-version information structures.
-        u'translations': {
+        'translations': {
             'lang_id1' : {
-                u'Comments':         u'日本語, Unicode 対応.',
-                u'CompanyName':      u'your company.',
-                u'FileDescription':  u'your file desc.',
-                u'FileVersion':      u'1, 2, 3, 4',
-                u'InternalName':     u'your internal name.',
-                u'LegalCopyright':   u'your legal copyright.',
-                u'LegalTrademarks':  u'your legal trademarks.',
-                u'OriginalFilename': u'your original filename.',
-                u'PrivateBuild':     u'5, 6, 7, 8',
-                u'ProductName':      u'your product name',
-                u'ProductVersion':   u'9, 10, 11, 12',
-                u'SpecialBuild':     u'13, 14, 15, 16',
+                'Comments':         '日本語, Unicode 対応.',
+                'CompanyName':      'your company.',
+                'FileDescription':  'your file desc.',
+                'FileVersion':      '1, 2, 3, 4',
+                'InternalName':     'your internal name.',
+                'LegalCopyright':   'your legal copyright.',
+                'LegalTrademarks':  'your legal trademarks.',
+                'OriginalFilename': 'your original filename.',
+                'PrivateBuild':     '5, 6, 7, 8',
+                'ProductName':      'your product name',
+                'ProductVersion':   '9, 10, 11, 12',
+                'SpecialBuild':     '13, 14, 15, 16',
             },
 
             'lang_id2' : {
@@ -86,9 +85,9 @@ def pefile_read_version(filename):
     #vers = pe.FileInfo[0].StringTable[0].entries
     from pprint import pprint
     pprint(pe.VS_FIXEDFILEINFO)
-    print(dir(pe.VS_FIXEDFILEINFO))
-    print(repr(pe.VS_FIXEDFILEINFO))
-    print(pe.dump_info())
+    print((dir(pe.VS_FIXEDFILEINFO)))
+    print((repr(pe.VS_FIXEDFILEINFO)))
+    print((pe.dump_info()))
     pe.close()
     return vers
 
@@ -97,19 +96,19 @@ def pefile_read_version(filename):
 # Ensures no code from the executable is executed.
 LOAD_LIBRARY_AS_DATAFILE = 2
 
-STRINGTYPE = type(u'')
+STRINGTYPE = type('')
 
 
 def getRaw(o):
-    return str(buffer(o))
-
+    return memoryview(o)
+    
 
 def decode(pathnm):
     h = win32api.LoadLibraryEx(pathnm, 0, LOAD_LIBRARY_AS_DATAFILE)
     nm = win32api.EnumResourceNames(h, pefile.RESOURCE_TYPE['RT_VERSION'])[0]
     data = win32api.LoadResource(h, pefile.RESOURCE_TYPE['RT_VERSION'], nm)
     vs = VSVersionInfo()
-    j = vs.fromRaw(data)
+    vs.fromRaw(data)
     win32api.FreeLibrary(h)
     return vs
 
@@ -135,7 +134,7 @@ class VSVersionInfo:
     def fromRaw(self, data):
         i, (sublen, vallen, wType, nm) = parseCommon(data)
         #vallen is length of the ffi, typ is 0, nm is 'VS_VERSION_INFO'.
-        i = ((i + 3) / 4) * 4
+        i =  int((i + 3) / 4) * 4
         # Now a VS_FIXEDFILEINFO
         self.ffi = FixedFileInfo()
         j = self.ffi.fromRaw(data, i)
@@ -143,7 +142,7 @@ class VSVersionInfo:
         while i < sublen:
             j = i
             i, (csublen, cvallen, ctyp, nm) = parseCommon(data, i)
-            if unicode(nm).strip() == u'StringFileInfo':
+            if str(nm).strip() == 'StringFileInfo':
                 sfi = StringFileInfo()
                 k = sfi.fromRaw(csublen, cvallen, nm, data, i, j+csublen)
                 self.kids.append(sfi)
@@ -154,33 +153,33 @@ class VSVersionInfo:
                 self.kids.append(vfi)
                 i = k
             i = j + csublen
-            i = ((i + 3) / 4) * 4
+            i =  int((i + 3) / 4) * 4
         return i
 
     def toRaw(self):
-        nm = pywintypes.Unicode(u'VS_VERSION_INFO')
+        nm = 'VS_VERSION_INFO'.encode('UTF-16LE')
         rawffi = self.ffi.toRaw()
         vallen = len(rawffi)
         typ = 0
-        sublen = 6 + 2*len(nm) + 2
-        pad = ''
+        sublen = 6 + len(nm) + 2
+        pad = b''
         if sublen % 4:
-            pad = '\000\000'
+            pad = b'\000\000'
         sublen = sublen + len(pad) + vallen
-        pad2 = ''
+        pad2 = b''
         if sublen % 4:
-            pad2 = '\000\000'
-        tmp = "".join([kid.toRaw() for kid in self.kids ])
+            pad2 = b'\000\000'
+        tmp = b"".join([kid.toRaw() for kid in self.kids ])
         sublen = sublen + len(pad2) + len(tmp)
         return (struct.pack('hhh', sublen, vallen, typ)
-                + getRaw(nm) + '\000\000' + pad + rawffi + pad2 + tmp)
+                + getRaw(nm) + b'\000\000' + pad + rawffi + pad2 + tmp)
 
-    def __unicode__(self, indent=u''):
-        indent = indent + u'  '
-        tmp = [kid.__unicode__(indent+u'  ')
+    def __str__(self, indent=''):
+        indent = indent + '  '
+        tmp = [kid.__str__(indent+'  ')
                for kid in self.kids]
-        tmp = u', \n'.join(tmp)
-        return (u"""# UTF-8
+        tmp = ', \n'.join(tmp)
+        return ("""# UTF-8
 #
 # For more details about fixed file info 'ffi' see:
 # http://msdn.microsoft.com/en-us/library/ms646997.aspx
@@ -190,7 +189,7 @@ VSVersionInfo(
 %s
 %s]
 )
-""" % (indent, self.ffi.__unicode__(indent), indent, tmp, indent))
+""" % (indent, self.ffi.__str__(indent), indent, tmp, indent))
 
 
 def parseCommon(data, start=0):
@@ -202,10 +201,10 @@ def parseCommon(data, start=0):
 def parseUString(data, start, limit):
     i = start
     while i < limit:
-        if data[i:i+2] == '\000\000':
+        if data[i:i+2] == b'\000\000':
             break
         i += 2
-    text = unicode(data[start:i], 'UTF-16LE')
+    text = str(data[start:i], 'UTF-16LE')
     i += 2
     return i, text
 
@@ -282,35 +281,35 @@ class FixedFileInfo:
                              self.fileDateMS,
                              self.fileDateLS)
 
-    def __unicode__(self, indent=u''):
+    def __str__(self, indent=''):
         fv = (self.fileVersionMS >> 16, self.fileVersionMS & 0xffff,
               self.fileVersionLS >> 16, self.fileVersionLS & 0xFFFF)
         pv = (self.productVersionMS >> 16, self.productVersionMS & 0xffff,
               self.productVersionLS >> 16, self.productVersionLS & 0xFFFF)
         fd = (self.fileDateMS, self.fileDateLS)
-        tmp = [u'FixedFileInfo(',
-            u'# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
-            u'# Set not needed items to zero 0.',
-            u'filevers=%s,' % unicode(fv),
-            u'prodvers=%s,' % unicode(pv),
-            u"# Contains a bitmask that specifies the valid bits 'flags'r",
-            u'mask=%s,' % hex(self.fileFlagsMask),
-            u'# Contains a bitmask that specifies the Boolean attributes of the file.',
-            u'flags=%s,' % hex(self.fileFlags),
-            u'# The operating system for which this file was designed.',
-            u'# 0x4 - NT and there is no need to change it.',
-            u'OS=%s,' % hex(self.fileOS),
-            u'# The general type of file.',
-            u'# 0x1 - the file is an application.',
-            u'fileType=%s,' % hex(self.fileType),
-            u'# The function of the file.',
-            u'# 0x0 - the function is not defined for this fileType',
-            u'subtype=%s,' % hex(self.fileSubtype),
-            u'# Creation date and time stamp.',
-            u'date=%s' % unicode(fd),
-            u')'
+        tmp = ['FixedFileInfo(',
+            '# filevers and prodvers should be always a tuple with four items: (1, 2, 3, 4)',
+            '# Set not needed items to zero 0.',
+            'filevers=%s,' % str(fv),
+            'prodvers=%s,' % str(pv),
+            "# Contains a bitmask that specifies the valid bits 'flags'r",
+            'mask=%s,' % hex(self.fileFlagsMask),
+            '# Contains a bitmask that specifies the Boolean attributes of the file.',
+            'flags=%s,' % hex(self.fileFlags),
+            '# The operating system for which this file was designed.',
+            '# 0x4 - NT and there is no need to change it.',
+            'OS=%s,' % hex(self.fileOS),
+            '# The general type of file.',
+            '# 0x1 - the file is an application.',
+            'fileType=%s,' % hex(self.fileType),
+            '# The function of the file.',
+            '# 0x0 - the function is not defined for this fileType',
+            'subtype=%s,' % hex(self.fileSubtype),
+            '# Creation date and time stamp.',
+            'date=%s' % str(fd),
+            ')'
         ]
-        return (u'\n'+indent+u'  ').join(tmp)
+        return ('\n'+indent+'  ').join(tmp)
 
 
 class StringFileInfo(object):
@@ -324,7 +323,7 @@ class StringFileInfo(object):
     StringTable Children[];   // list of zero or more String structures
     """
     def __init__(self, kids=None):
-        self.name = u'StringFileInfo'
+        self.name = 'StringFileInfo'
         self.kids = kids or []
 
     def fromRaw(self, sublen, vallen, name, data, i, limit):
@@ -338,26 +337,26 @@ class StringFileInfo(object):
 
     def toRaw(self):
         if type(self.name) is STRINGTYPE:
-            self.name = pywintypes.Unicode(self.name)
+            self.name = self.name.encode('UTF-16LE')
         vallen = 0
         typ = 1
-        sublen = 6 + 2*len(self.name) + 2
-        pad = ''
+        sublen = 6 + len(self.name) + 2
+        pad = b''
         if sublen % 4:
-            pad = '\000\000'
-        tmp = ''.join([kid.toRaw() for kid in self.kids])
+            pad = b'\000\000'
+        tmp = b''.join([kid.toRaw() for kid in self.kids])
         sublen = sublen + len(pad) + len(tmp)
-        if tmp[-2:] == '\000\000':
+        if tmp[-2:] == b'\000\000':
             sublen = sublen - 2
         return (struct.pack('hhh', sublen, vallen, typ)
-                + getRaw(self.name) + '\000\000' + pad + tmp)
+                + getRaw(self.name) + b'\000\000' + pad + tmp)
 
-    def __unicode__(self, indent=u''):
-        newindent = indent + u'  '
-        tmp = [kid.__unicode__(newindent)
+    def __str__(self, indent=''):
+        newindent = indent + '  '
+        tmp = [kid.__str__(newindent)
                for kid in self.kids]
-        tmp = u', \n'.join(tmp)
-        return (u'%sStringFileInfo(\n%s[\n%s\n%s])'
+        tmp = ', \n'.join(tmp)
+        return ('%sStringFileInfo(\n%s[\n%s\n%s])'
                 % (indent, newindent, tmp, newindent))
 
 
@@ -370,44 +369,44 @@ class StringTable:
     String Children[];    // list of zero or more String structures.
     """
     def __init__(self, name=None, kids=None):
-        self.name = name or u''
+        self.name = name or ''
         self.kids = kids or []
 
     def fromRaw(self, data, i, limit):
         i, (cpsublen, cpwValueLength, cpwType, self.name) = parseCodePage(data, i, limit) # should be code page junk
-        #i = ((i + 3) / 4) * 4
+        #i =  int((i + 3) / 4) * 4
         while i < limit:
             ss = StringStruct()
             j = ss.fromRaw(data, i, limit)
             i = j
             self.kids.append(ss)
-            i = ((i + 3) / 4) * 4
+            i =  int((i + 3) / 4) * 4
         return i
 
     def toRaw(self):
         if type(self.name) is STRINGTYPE:
-            self.name = pywintypes.Unicode(self.name)
+            self.name = self.name.encode('UTF-16LE')
         vallen = 0
         typ = 1
-        sublen = 6 + 2*len(self.name) + 2
+        sublen = 6 + len(self.name) + 2
         tmp = []
         for kid in self.kids:
             raw = kid.toRaw()
             if len(raw) % 4:
-                raw = raw + '\000\000'
+                raw = raw + b'\000\000'
             tmp.append(raw)
-        tmp = ''.join(tmp)
+        tmp = b''.join(tmp)
         sublen += len(tmp)
-        if tmp[-2:] == '\000\000':
+        if tmp[-2:] == b'\000\000':
             sublen -= 2
         return (struct.pack('hhh', sublen, vallen, typ)
-                + getRaw(self.name) + '\000\000' + tmp)
+                + getRaw(self.name) + b'\000\000' + tmp)
 
-    def __unicode__(self, indent=u''):
-        newindent = indent + u'  '
-        tmp = map(unicode, self.kids)
-        tmp = (u',\n%s' % newindent).join(tmp)
-        return (u"%sStringTable(\n%su'%s',\n%s[%s])"
+    def __str__(self, indent=''):
+        newindent = indent + '  '
+        tmp = map(str, self.kids)
+        tmp = (',\n%s' % newindent).join(tmp)
+        return ("%sStringTable(\n%su'%s',\n%s[%s])"
                 % (indent, newindent, self.name, newindent, tmp))
 
 
@@ -421,13 +420,13 @@ class StringStruct:
     String Value[];
     """
     def __init__(self, name=None, val=None):
-        self.name = name or u''
-        self.val = val or u''
+        self.name = name or ''
+        self.val = val or ''
 
     def fromRaw(self, data, i, limit):
         i, (sublen, vallen, typ, self.name) = parseCommon(data, i)
         limit = i + sublen
-        i = ((i + 3) / 4) * 4
+        i =  int((i + 3) / 4) * 4
         i, self.val = parseUString(data, i, limit)
         return i
 
@@ -442,17 +441,17 @@ class StringStruct:
         vallen = len(raw_val) + 2
         typ = 1
         sublen = 6 + len(raw_name) + 2
-        pad = ''
+        pad = b''
         if sublen % 4:
-            pad = '\000\000'
+            pad = b'\000\000'
         sublen = sublen + len(pad) + vallen
         abcd = (struct.pack('hhh', sublen, vallen, typ)
-                + raw_name + '\000\000' + pad
-                + raw_val + '\000\000')
+                + raw_name + b'\000\000' + pad
+                + raw_val + b'\000\000')
         return abcd
 
-    def __unicode__(self, indent=''):
-        return u"StringStruct(u'%s', u'%s')" % (self.name, self.val) 
+    def __str__(self, indent=''):
+        return "StringStruct('%s', '%s')" % (self.name, self.val) 
 
 
 def parseCodePage(data, i, limit):
@@ -477,7 +476,7 @@ class VarFileInfo:
         self.sublen = sublen
         self.vallen = vallen
         self.name = name
-        i = ((i + 3) / 4) * 4
+        i =  int((i + 3) / 4) * 4
         while i < limit:
             vs = VarStruct()
             j = vs.fromRaw(data, i, limit)
@@ -488,18 +487,18 @@ class VarFileInfo:
     def toRaw(self):
         self.vallen = 0
         self.wType = 1
-        self.name = pywintypes.Unicode('VarFileInfo')
-        sublen = 6 + 2*len(self.name) + 2
-        pad = ''
+        self.name = 'VarFileInfo'.encode('UTF-16LE')
+        sublen = 6 + len(self.name) + 2
+        pad = b''
         if sublen % 4:
-            pad = '\000\000'
-        tmp = ''.join([kid.toRaw() for kid in self.kids])
+            pad = b'\000\000'
+        tmp = b''.join([kid.toRaw() for kid in self.kids])
         self.sublen = sublen + len(pad) + len(tmp)
         return (struct.pack('hhh', self.sublen, self.vallen, self.wType)
-                + getRaw(self.name) + '\000\000' + pad + tmp)
+                + getRaw(self.name) + b'\000\000' + pad + tmp)
 
-    def __unicode__(self, indent=''):
-        tmp = map(unicode, self.kids)
+    def __str__(self, indent=''):
+        tmp = list(map(str, self.kids))
         return "%sVarFileInfo([%s])" % (indent, ', '.join(tmp))
 
 
@@ -516,13 +515,13 @@ class VarStruct:
                           // and code-page identifiers
     """
     def __init__(self, name=None, kids=None):
-        self.name = name or u''
+        self.name = name or ''
         self.kids = kids or []
 
     def fromRaw(self, data, i, limit):
         i, (self.sublen, self.wValueLength, self.wType, self.name) = parseCommon(data, i)
-        i = ((i + 3) / 4) * 4
-        for j in range(self.wValueLength/2):
+        i =  int((i + 3) / 4) * 4
+        for j in range(int(self.wValueLength/2)):
             kid = struct.unpack('h', data[i:i+2])[0]
             self.kids.append(kid)
             i += 2
@@ -532,18 +531,18 @@ class VarStruct:
         self.wValueLength = len(self.kids) * 2
         self.wType = 0
         if type(self.name) is STRINGTYPE:
-            self.name = pywintypes.Unicode(self.name)
-        sublen = 6 + 2*len(self.name) + 2
-        pad = ''
+            self.name = self.name.encode('UTF-16LE')
+        sublen = 6 + len(self.name) + 2
+        pad = b''
         if sublen % 4:
-            pad = '\000\000'
+            pad = b'\000\000'
         self.sublen = sublen + len(pad) + self.wValueLength
-        tmp = ''.join([struct.pack('h', kid) for kid in self.kids])
+        tmp = b''.join([struct.pack('h', kid) for kid in self.kids])
         return (struct.pack('hhh', self.sublen, self.wValueLength, self.wType)
-                + getRaw(self.name) + '\000\000' + pad + tmp)
+                + getRaw(self.name) + b'\000\000' + pad + tmp)
 
-    def __unicode__(self, indent=u''):
-        return u"VarStruct(u'%s', %r)" % (self.name, self.kids)
+    def __str__(self, indent=''):
+        return "VarStruct('%s', %r)" % (self.name, self.kids)
 
 
 def SetVersion(exenm, versionfile):


### PR DESCRIPTION
I started to work on porting the versioninfo module to Python 3 so that pyi-grab_version and pyi-set_version can work again

More work is needed to get a module usable on both Python 2 and 3.